### PR TITLE
fix: correct duplicate mq_channel in pre_checks error message

### DIFF
--- a/tasks/pre_checks.yaml
+++ b/tasks/pre_checks.yaml
@@ -1,6 +1,6 @@
 - name: Fail if mq_qmgr or mq_qmgr are not defined
   ansible.builtin.fail:
-    msg: "Make sure mq_channel and mq_channel are provided."
+    msg: "Make sure mq_qmgr and mq_channel are provided."
   when: "'mq_qmgr' is not defined or 'mq_channel' is not defined"
 
 - name: Check requested actions

--- a/tasks/pre_checks.yaml
+++ b/tasks/pre_checks.yaml
@@ -1,7 +1,7 @@
-- name: Fail if mq_qmgr or mq_qmgr are not defined
+- name: Fail if mq_qmgr or mq_channel are not defined
   ansible.builtin.fail:
     msg: "Make sure mq_qmgr and mq_channel are provided."
-  when: "'mq_qmgr' is not defined or 'mq_channel' is not defined"
+  when: "mq_qmgr is not defined or mq_channel is not defined"
 
 - name: Check requested actions
   ansible.builtin.fail:


### PR DESCRIPTION
The fail message incorrectly named mq_channel twice; first occurrence should be mq_qmgr to match the actual variable being checked.