### PR TITLE
fix: correct invalid Jinja2 'is in' operator to 'in'

### DIFF
--- a/tasks/start_channel.yaml
+++ b/tasks/start_channel.yaml
@@ -3,7 +3,7 @@
   - ansible.builtin.debug:
       msg: "Channel is already started. No further actions required."
   - meta: end_play
-  when: "'STATUS(RUNNING)' is in display_channel_out.stdout"
+  when: "'STATUS(RUNNING)' in display_channel_out.stdout"
 
 - name: Start channel
   ansible.builtin.shell:

--- a/tasks/stop_channel.yaml
+++ b/tasks/stop_channel.yaml
@@ -3,7 +3,7 @@
   - ansible.builtin.debug:
       msg: "Channel is already stopped. No further actions required."
   - meta: end_play
-  when: "'STATUS(RUNNING)' is not in display_channel_out.stdout"
+  when: "'STATUS(RUNNING)' not in display_channel_out.stdout"
 
 - name: Stop channel
   ansible.builtin.shell:


### PR DESCRIPTION
## Summary

- `'STATUS(RUNNING)' is in ...` and `'STATUS(RUNNING)' is not in ...` are not valid Jinja2 syntax and cause a template error at runtime
- Fixed in both `tasks/start_channel.yaml` and `tasks/stop_channel.yaml` by replacing with `in` and `not in`

## Test plan

- [ ] Run the role with `mq_channel_action: START` against a stopped channel and confirm no Jinja2 template error
- [ ] Run the role with `mq_channel_action: STOP` against a running channel and confirm no Jinja2 template error

🤖 Generated with [Claude Code](https://claude.com/claude-code)