### PR TITLE
fix: check STATUS(RUNNING) absence instead of STATUS(STOPPED) presence

### DIFF
--- a/tasks/stop_channel.yaml
+++ b/tasks/stop_channel.yaml
@@ -19,4 +19,4 @@
   become: true
   become_user: "{{ mq_user if mq_user is defined else 'mqm'  }}"
   register: display_channel_after_stop
-  failed_when:  "'STATUS(STOPPED)' is not in display_channel_after_stop.stdout"
+  failed_when: "'STATUS(RUNNING)' in display_channel_after_stop.stdout"


### PR DESCRIPTION
## Summary

- A fully stopped MQ channel disappears from `CHSTATUS` entirely — `DISPLAY CHSTATUS` returns no record, so checking for `STATUS(STOPPED)` in the output always fails even on a successful stop
- Changed `failed_when` in `tasks/stop_channel.yaml` to check that `STATUS(RUNNING)` is absent, which is reliable in both cases

## Test plan

- [ ] Run the role with `mq_channel_action: STOP` against a running channel and confirm the post-stop verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)