### PR TITLE
fix: correct invalid Jinja2 'is not in' to 'not in' in start_channel

### DIFF
--- a/tasks/start_channel.yaml
+++ b/tasks/start_channel.yaml
@@ -19,4 +19,4 @@
   become: true
   become_user: "{{ mq_user if mq_user is defined else 'mqm'  }}"
   register: display_channel_after_start
-  failed_when:  "'STATUS(RUNNING)' is not in display_channel_after_start.stdout"
+  failed_when: "'STATUS(RUNNING)' not in display_channel_after_start.stdout"


### PR DESCRIPTION
## Summary

- `failed_when` in `tasks/start_channel.yaml` used `'STATUS(RUNNING)' is not in ...` which is invalid Jinja2 syntax and causes a template error at runtime
- The same issue was fixed in `stop_channel.yaml` in PR #5 but was missed here
- Corrected to `'STATUS(RUNNING)' not in ...`

## Test plan

- [ ] Run the role with `mq_channel_action: START` against a stopped channel and confirm the post-start verification passes without a Jinja2 template error

🤖 Generated with [Claude Code](https://claude.com/claude-code)